### PR TITLE
explicitly converted error message to string

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -380,7 +380,7 @@ class BorutaPy(BaseEstimator, TransformerMixin):
             self.estimator.fit(X, y)
         except Exception as e:
             raise ValueError('Please check your X and y variable. The provided'
-                             'estimator cannot be fitted to your data.\n' + e)
+                             'estimator cannot be fitted to your data.\n' + str(e))
         try:
             imp = self.estimator.feature_importances_
         except Exception:


### PR DESCRIPTION
Python 3.5 --
Explicitly converted error message to string in the definition of the **_get_imp()** function, otherwise a type error is raised (TypeError: Can't convert 'ValueError' object to str implicitly).
See **str(e)** below:

```
    def _get_imp(self, X, y):
        try:
            self.estimator.fit(X, y)
        except Exception as e:
            raise ValueError('Please check your X and y variable. The provided'
                             'estimator cannot be fitted to your data.\n' + str(e))
        try:
            imp = self.estimator.feature_importances_
        except Exception:
            raise ValueError('Only methods with feature_importance_ attribute '
                             'are currently supported in BorutaPy.')
        return imp
```