### PR TITLE
solved the NA issue in _assign_hits()

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -415,7 +415,8 @@ class BorutaPy(BaseEstimator, TransformerMixin):
 
     def _assign_hits(self, hit_reg, cur_imp, imp_sha_max):
         # register hits for feautres that did better than the best of shadows
-        hits = np.where(cur_imp[0] > imp_sha_max)[0]
+        cur_imp_no_nan = [val for val in cur_imp[0] if not np.isnan(val)]
+        hits = np.where(cur_imp_no_nan > imp_sha_max)[0]
         hit_reg[hits] += 1
         return hit_reg
 

--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -414,7 +414,7 @@ class BorutaPy(BaseEstimator, TransformerMixin):
         return imp_real, imp_sha
 
     def _assign_hits(self, hit_reg, cur_imp, imp_sha_max):
-        # register hits for feautres that did better than the best of shadows
+        # register hits for features that did better than the best of shadows
         cur_imp_no_nan = [val for val in cur_imp[0] if not np.isnan(val)]
         hits = np.where(cur_imp_no_nan > imp_sha_max)[0]
         hit_reg[hits] += 1


### PR DESCRIPTION
Solved NA issue in the `_assign_hits()` function, reported by several users (`https://github.com/scikit-learn-contrib/boruta_py/issues/30)`.

Message error `RuntimeWarning: invalid value encountered in greater hits = np.where(cur_imp[0] > imp_sha_max)[0] ` was due to numpy comparison with NAs.

Fix was to remove any possible NAs from the `cur_imp[0]` numpy array. This fix has NO impact on the workings of the algorithm _per se_.