### PR TITLE
Fix TypeError: iteration over a 0-d array error when no features are rejected

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -331,20 +331,24 @@ class BorutaPy(BaseEstimator, TransformerMixin):
         not_selected = np.setdiff1d(np.arange(n_feat), selected)
         # large importance values should rank higher = lower ranks -> *(-1)
         imp_history_rejected = imp_history[1:, not_selected] * -1
-        # calculate ranks in each iteration, then median of ranks across feats
-        iter_ranks = self._nanrankdata(imp_history_rejected, axis=1)
-        rank_medians = np.nanmedian(iter_ranks, axis=0)
-        ranks = self._nanrankdata(rank_medians, axis=0)
 
         # update rank for not_selected features
-        if not_selected.shape[0] > 0:
-            # set smallest rank to 3 if there are tentative feats
-            if tentative.shape[0] > 0:
-                ranks = ranks - np.min(ranks) + 3
-            else:
-                # and 2 otherwise
-                ranks = ranks - np.min(ranks) + 2
-            self.ranking_[not_selected] = ranks
+        if not_selected.shape[0] > 0 and not_selected.shape[1] > 0:
+                # calculate ranks in each iteration, then median of ranks across feats
+                iter_ranks = self._nanrankdata(imp_history_rejected, axis=1)
+                rank_medians = np.nanmedian(iter_ranks, axis=0)
+                ranks = self._nanrankdata(rank_medians, axis=0)
+
+                # set smallest rank to 3 if there are tentative feats
+                if tentative.shape[0] > 0:
+                    ranks = ranks - np.min(ranks) + 3
+                else:
+                    # and 2 otherwise
+                    ranks = ranks - np.min(ranks) + 2
+                self.ranking_[not_selected] = ranks
+        else:
+            # all are selected, thus we set feature supports to True
+            self.support_ = np.ones(n_feat, dtype=np.bool)
 
         # notify user
         if self.verbose > 0:


### PR DESCRIPTION
Hi there,

This PR should provide a fix to the error of `TypeError: iteration over a 0-d array` from `self._nanrankdata` function.
It relates to the past ticket #16.

In my test cases, the error is triggered when all features seem to be important and caused the  `not_selected` variable become an empty array `[]` with a shape of `(0,)`:

```python
# all rejected features are sorted by importance history
not_selected = np.setdiff1d(np.arange(n_feat), selected)
```
After that `imp_history_rejected`, a 0-d array with a shape of `(len(imp_history)-1, 0)`, is used as the input to the `self._nanrankdata` function, and further triggers the error.
```python
# large importance values should rank higher = lower ranks -> *(-1)
imp_history_rejected = imp_history[1:, not_selected] * -1

# calculate ranks in each iteration, then median of ranks across feats
iter_ranks = self._nanrankdata(imp_history_rejected, axis=1)
......
```

The fix here is to make sure that all dimensions of `not_selected` are greater than zero. If not, it assumes that we should keep all features as important and set their `_support` to True.
```python
# all are selected, thus we set feature supports to True
self.support_ = np.ones(n_feat, dtype=np.bool)
```
