### PR TITLE
fixing reference to self.is_lgb

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -303,7 +303,7 @@ class BorutaPy(BaseEstimator, TransformerMixin):
                 self.estimator.set_params(n_estimators=n_tree)
 
             # make sure we start with a new tree in each iteration
-            if self.is_lgb:
+            if self._is_lightgbm:
                 self.estimator.set_params(random_state=self.random_state.randint(0, 10000))
             else:
                 self.estimator.set_params(random_state=self.random_state)


### PR DESCRIPTION
There was a lost reference to self.is_lgb but now we use self._is_lightgbm. That causes an error to be fixed by replacing self.is_lgb with self._is_lightgbm.