### PR TITLE
return importance history from fit

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -136,6 +136,10 @@ class BorutaPy(BaseEstimator, TransformerMixin):
         best) features are assigned rank 1 and tentative features are assigned
         rank 2.
 
+    importance_history_ : array-like, shape [n_features, n_iters]
+
+        The calculated importance values for each feature across all iterations.  
+
     Examples
     --------
     
@@ -377,6 +381,8 @@ class BorutaPy(BaseEstimator, TransformerMixin):
         else:
             # all are selected, thus we set feature supports to True
             self.support_ = np.ones(n_feat, dtype=np.bool)
+
+        self.importance_history_ = imp_history
 
         # notify user
         if self.verbose > 0:


### PR DESCRIPTION
Addresses issue #87. You already collect the importance histories. Simply adding it to the selector object so that it will be available after calling fit. 