### PR TITLE
Early stopping support

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -117,13 +117,13 @@ class BorutaPy(BaseEstimator, TransformerMixin):
     early_stopping : bool, default = False
         Whether to use early stopping to terminate the selection process
         before reaching `max_iter` iterations if the algorithm cannot
-        confirm a tenative feature for `n_iter_no_change` iterations.
+        confirm a tentative feature for `n_iter_no_change` iterations.
         Will speed up the process at a cost of a possibility of a
         worse result.
         
     n_iter_no_change : int, default = 20
         Ignored if `early_stopping` is False. The maximum amount of
-        iterations without confirming a tenative feature. 
+        iterations without confirming a tentative feature. 
 
     Attributes
     ----------


### PR DESCRIPTION
It is often possible that the algorithm will not be able to decide whether a feature is confirmed or rejected within the given amount of iterations - in that case, one can consider all of the iterations which do not change the final decisions as wasted. A solution to that problem is to introduce early stopping.

If the user sets `early_stopping=True`, then if the `dec_reg` array does not change for `n_iter_no_change` iterations (default 20), the loop will break. Whenever `dec_reg` changes, the counter for early stopping will be reset.

This feature will help in cases where time performance is a concern. The default behavior is unchanged.