### PR TITLE
numpy type aliases replaced by builtin types

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -316,12 +316,12 @@ class BorutaPy(BaseEstimator, TransformerMixin):
         # 0  - default state = tentative in original code
         # 1  - accepted in original code
         # -1 - rejected in original code
-        dec_reg = np.zeros(n_feat, dtype=np.int)
+        dec_reg = np.zeros(n_feat, dtype=int)
         # counts how many times a given feature was more important than
         # the best of the shadow features
-        hit_reg = np.zeros(n_feat, dtype=np.int)
+        hit_reg = np.zeros(n_feat, dtype=int)
         # these record the history of the iterations
-        imp_history = np.zeros(n_feat, dtype=np.float)
+        imp_history = np.zeros(n_feat, dtype=float)
         sha_max_history = []
 
         # set n_estimators
@@ -393,13 +393,13 @@ class BorutaPy(BaseEstimator, TransformerMixin):
 
         # basic result variables
         self.n_features_ = confirmed.shape[0]
-        self.support_ = np.zeros(n_feat, dtype=np.bool)
+        self.support_ = np.zeros(n_feat, dtype=bool)
         self.support_[confirmed] = 1
-        self.support_weak_ = np.zeros(n_feat, dtype=np.bool)
+        self.support_weak_ = np.zeros(n_feat, dtype=bool)
         self.support_weak_[tentative] = 1
 
         # ranking, confirmed variables are rank 1
-        self.ranking_ = np.ones(n_feat, dtype=np.int)
+        self.ranking_ = np.ones(n_feat, dtype=int)
         # tentative variables are rank 2
         self.ranking_[tentative] = 2
         # selected = confirmed and tentative
@@ -425,7 +425,7 @@ class BorutaPy(BaseEstimator, TransformerMixin):
                 self.ranking_[not_selected] = ranks
         else:
             # all are selected, thus we set feature supports to True
-            self.support_ = np.ones(n_feat, dtype=np.bool)
+            self.support_ = np.ones(n_feat, dtype=bool)
 
         self.importance_history_ = imp_history
 


### PR DESCRIPTION
Dear devs,
This PR addresses the issue that I posted here: https://github.com/scikit-learn-contrib/boruta_py/issues/101
Implemented changes include:

- replacing `np.float` by `float`
- replacing `np.bool` by `bool`
- replacing `np.int` by `int`