### PR TITLE
Bump up gh-action-pypi-publish to v1.9.0

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,6 +15,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC for PyPi Trusted Publisher feature
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -36,6 +38,4 @@ jobs:
     - name: Build a binary wheel
       run: python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.10
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@v1.9.0


### PR DESCRIPTION
Remove use of token, use trusted provider instead:
https://github.com/pypa/gh-action-pypi-publish/?tab=readme-ov-file#trusted-publishing

@danielhomola can you follow the instructions at: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
to add GitHub as a trusted publisher to the https://pypi.org/project/Boruta/ repository?

This seems to be the latest recommended practice for publishing from GitHub to Pypi.
