### PR TITLE
Remove bespoke transform method

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -283,14 +283,6 @@ class BorutaPy(BaseEstimator, SelectorMixin):
         return_df = fit_params.pop("return_df", None)
         return self.fit(X, y, **fit_params).transform(X, weak=weak, return_df=return_df)
 
-    def _validate_pandas_input(self, arg):
-        try:
-            return arg.values
-        except AttributeError:
-            raise ValueError(
-                "input needs to be a numpy array or pandas data frame."
-            )
-
     def _fit(self, X, y):
         # check input params
         self._check_params(X, y)
@@ -301,10 +293,7 @@ class BorutaPy(BaseEstimator, SelectorMixin):
         else:
             self.feature_names_in_ = None
 
-        if not isinstance(X, np.ndarray):
-            X = self._validate_pandas_input(X) 
-        if not isinstance(y, np.ndarray):
-            y = self._validate_pandas_input(y)
+        X, y = check_X_y(X, y, accept_sparse=False, ensure_2d=True, dtype=None, estimator=self)
 
         self.n_features_in_ = X.shape[1]
 

--- a/boruta/test/test_boruta.py
+++ b/boruta/test/test_boruta.py
@@ -1,6 +1,9 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn import config_context
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.tree import DecisionTreeClassifier, ExtraTreeClassifier
@@ -65,8 +68,53 @@ def test_dataframe_is_returned(Xy):
     X_df, y_df = pd.DataFrame(X), pd.Series(y)
     rfc = RandomForestClassifier()
     bt = BorutaPy(rfc)
-    bt.fit(X_df, y_df)
-    assert isinstance(bt.transform(X_df, return_df=True), pd.DataFrame)
+    with config_context(transform_output="pandas"):
+        bt.fit(X_df, y_df)
+        transformed = bt.transform(X_df)
+    assert isinstance(transformed, pd.DataFrame)
+
+
+def test_return_df_parameter_emits_warning(Xy):
+    X, y = Xy
+    X_df, y_df = pd.DataFrame(X), pd.Series(y)
+    bt = BorutaPy(RandomForestClassifier())
+    with config_context(transform_output="pandas"):
+        bt.fit(X_df, y_df)
+        with pytest.warns(FutureWarning, match=re.escape("`set_output(transform='pandas')`")):
+            transformed = bt.transform(X_df, return_df=True)
+    assert isinstance(transformed, pd.DataFrame)
+
+
+def test_weak_attribute_controls_support_mask(Xy):
+    X, y = Xy
+    bt = BorutaPy(RandomForestClassifier(), weak=True)
+    bt.fit(X, y)
+
+    union_mask = bt.support_ | bt.support_weak_
+    assert np.array_equal(bt.get_support(), union_mask)
+
+
+def test_transform_with_weak_parameter_is_deprecated(Xy):
+    X, y = Xy
+    bt = BorutaPy(RandomForestClassifier())
+    bt.fit(X, y)
+    bt.support_[5] = False
+    bt.support_weak_[5] = True
+
+    with pytest.warns(FutureWarning, match=re.escape("`weak` is deprecated")):
+        transformed = bt.transform(X, weak=True)
+
+    expected_features = np.count_nonzero(bt.support_ | bt.support_weak_)
+    assert transformed.shape[1] == expected_features
+
+
+def test_fit_transform_with_weak_parameter_is_deprecated(Xy):
+    X, y = Xy
+    bt = BorutaPy(RandomForestClassifier())
+    with pytest.warns(FutureWarning, match=re.escape("`weak` is deprecated")):
+        transformed = bt.fit_transform(X, y, weak=True)
+    expected_features = np.count_nonzero(bt.support_ | bt.support_weak_)
+    assert transformed.shape[1] == expected_features
 
 
 def test_selector_mixin_get_support_requires_fit():

--- a/boruta/test/test_boruta.py
+++ b/boruta/test/test_boruta.py
@@ -85,6 +85,33 @@ def test_return_df_parameter_emits_warning(Xy):
     assert isinstance(transformed, pd.DataFrame)
 
 
+def test_return_df_true_temporarily_enables_pandas_output(Xy):
+    X, y = Xy
+    bt = BorutaPy(RandomForestClassifier())
+    bt.fit(X, y)
+
+    baseline = bt.transform(X)
+    assert isinstance(baseline, np.ndarray)
+
+    with pytest.warns(FutureWarning, match="`return_df` is deprecated"):
+        transformed = bt.transform(X, return_df=True)
+    assert isinstance(transformed, pd.DataFrame)
+
+    reverted = bt.transform(X)
+    assert isinstance(reverted, np.ndarray)
+
+
+def test_return_df_false_with_dataframe_input_returns_numpy(Xy):
+    X, y = Xy
+    X_df = pd.DataFrame(X)
+    bt = BorutaPy(RandomForestClassifier())
+    bt.fit(X_df, y)
+
+    with pytest.warns(FutureWarning, match="`return_df` is deprecated"):
+        transformed = bt.transform(X_df, return_df=False)
+    assert isinstance(transformed, np.ndarray)
+
+
 def test_weak_attribute_controls_support_mask(Xy):
     X, y = Xy
     bt = BorutaPy(RandomForestClassifier(), weak=True)


### PR DESCRIPTION
This removes the bespoke `_transform` method to reuse the one from the superclass as discussed in #145. To support backwards compatibility, legacy arguments are still applied (and then un-applied) in `transform`; once we decide to push a breaking release and drop support for these legacy arguments, the whole `transform` method (and `fit_transform`) can be removed.

I also took the liberty of replacing `_validate_pandas_input` with sklearn's `check_X_y`.